### PR TITLE
Remove FQDN from staging site

### DIFF
--- a/config.staging.yml
+++ b/config.staging.yml
@@ -1,7 +1,7 @@
 author: Nick Pegg
 title: Nick Pegg
 # description: ''
-base_url: https://test2.nickpegg.com/
+base_url: /
 
 num_top_tags: 5
 num_posts_per_page: 5


### PR DESCRIPTION
Helps make the staging process not care about FQDN, so that it can be previewed anywhere (like Netlify!)